### PR TITLE
Fixed bug in Rings Puzzle & Camera Trigger

### DIFF
--- a/Delve Deeper Project/Assets/Scripts/Puzzle/RingPuzzleTrigger.cs
+++ b/Delve Deeper Project/Assets/Scripts/Puzzle/RingPuzzleTrigger.cs
@@ -1,0 +1,35 @@
+using UnityEngine;
+
+public enum RingPuzzleTriggerType
+{
+    OUTER = 0,
+    MIDDLE,
+    INNER
+}
+
+public enum RingPuzzleTriggerDirection
+{
+    Clockwise = 0,
+    AntiClockwise
+}
+
+public class RingPuzzleTrigger : MonoBehaviour, IInteractable
+{
+    public RingPuzzleTriggerType type;
+    public RingPuzzleTriggerDirection direction;
+
+    public string GetInteractText()
+    {
+        return "Rotate Pillar";
+    }
+
+    public Transform GetTransform()
+    {
+        return transform;
+    }
+
+    public void Interact(Transform interactorTransform)
+    {
+        
+    }
+}

--- a/Delve Deeper Project/Assets/Scripts/RingsCameraTrigger.cs
+++ b/Delve Deeper Project/Assets/Scripts/RingsCameraTrigger.cs
@@ -1,0 +1,45 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Cinemachine;
+using StarterAssets;
+
+public class RingsCameraTrigger : MonoBehaviour
+{
+    [SerializeField] CinemachineVirtualCamera puzzleCam;
+
+    private void Awake()
+    {
+        RingsPuzzle.OnRingsPuzzleCompleted += OnRingsPuzzleCompleted;
+    }
+
+    private void OnDestroy()
+    {
+        RingsPuzzle.OnRingsPuzzleCompleted -= OnRingsPuzzleCompleted;
+    }
+
+    private void OnTriggerEnter(Collider other)
+    {
+        if (other.GetComponent<ThirdPersonController>() != null)
+        {
+            puzzleCam.gameObject.SetActive(true);
+            puzzleCam.Priority = 99;
+        }
+    }
+
+    private void OnTriggerExit(Collider other)
+    {
+        if (other.GetComponent<ThirdPersonController>() != null)
+        {
+            puzzleCam.gameObject.SetActive(false);
+            puzzleCam.Priority = 0;
+        }
+    }
+
+    void OnRingsPuzzleCompleted()
+    {
+        puzzleCam.Priority = 0;
+        puzzleCam.gameObject.SetActive(false);
+        gameObject.SetActive(false);
+    }
+}

--- a/Delve Deeper Project/Assets/Scripts/RingsCameraTrigger.cs.meta
+++ b/Delve Deeper Project/Assets/Scripts/RingsCameraTrigger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c1ecaabfacdc91844b15ff6831675b22
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Delve Deeper Project/Assets/Scripts/RingsPuzzle.cs
+++ b/Delve Deeper Project/Assets/Scripts/RingsPuzzle.cs
@@ -1,7 +1,7 @@
 using StarterAssets;
-using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Events;
 
 public class RingsPuzzle : MonoBehaviour
 {
@@ -19,9 +19,15 @@ public class RingsPuzzle : MonoBehaviour
 
     public static bool RingsPuzzleCompleted = false;
 
+<<<<<<< Updated upstream:Delve Deeper Project/Assets/Scripts/RingsPuzzle.cs
     //[SerializeField] GameEvent allRingsAligned;
 
     PuzzleTrigger[] triggers;
+=======
+    public static UnityAction OnRingsPuzzleCompleted;
+
+    RingPuzzleTrigger[] triggers;
+>>>>>>> Stashed changes:Delve Deeper Project/Assets/Scripts/Puzzle/RingsPuzzle.cs
 
     CharacterController playerController;
     ThirdPersonController player;
@@ -163,6 +169,8 @@ public class RingsPuzzle : MonoBehaviour
         {
             lerpVal = 1f;
             VictoryLerpComplete = true;
+
+            OnRingsPuzzleCompleted?.Invoke();
         }
 
         outerPillars.localEulerAngles = Vector3.Lerp(outerStartVictory, outerEndVictory, lerpVal);

--- a/Delve Deeper Project/Assets/Scripts/RingsPuzzleControl.cs
+++ b/Delve Deeper Project/Assets/Scripts/RingsPuzzleControl.cs
@@ -12,8 +12,12 @@ public class RingsPuzzleControl : MonoBehaviour
 
     private void Awake()
     {
+<<<<<<< Updated upstream:Delve Deeper Project/Assets/Scripts/RingsPuzzleControl.cs
         puzzle = FindObjectOfType<RingsPuzzle>();
         player = FindObjectOfType<ThirdPersonController>();
+=======
+        player = GetComponent<ThirdPersonController>();
+>>>>>>> Stashed changes:Delve Deeper Project/Assets/Scripts/Puzzle/RingsPuzzleControl.cs
     }
 
     private void Update()
@@ -26,6 +30,8 @@ public class RingsPuzzleControl : MonoBehaviour
 
     private void OnTriggerEnter(Collider other)
     {
+        puzzle = FindObjectOfType<RingsPuzzle>();
+
         if (RingsPuzzle.RingsPuzzleCompleted)
             return;
     }
@@ -47,8 +53,21 @@ public class RingsPuzzleControl : MonoBehaviour
             if (pt != null)
             {
                 puzzle.RotatePillar(pt);
+<<<<<<< Updated upstream:Delve Deeper Project/Assets/Scripts/RingsPuzzleControl.cs
 
+=======
+                //player.HandlePushing(true);
+>>>>>>> Stashed changes:Delve Deeper Project/Assets/Scripts/Puzzle/RingsPuzzleControl.cs
             }
         }
+    }
+
+    private void OnTriggerExit(Collider other)
+    {
+        if (RingsPuzzle.RingsPuzzleCompleted)
+            return;
+
+        RingPuzzleTrigger pt = other.GetComponent<RingPuzzleTrigger>();
+        pt = null;
     }
 }


### PR DESCRIPTION
Found that due to scene loading, the reference to the RingsPuzzle script in RingsPuzzleControl on the player wasn't being picked up. Moved this to OnTrigger to ensure the correct puzzle is being referenced